### PR TITLE
remove notification from dom after it closes

### DIFF
--- a/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -34,7 +34,7 @@ public class Notification
 
     private Element container = new Element("div", false);
     private final Element templateElement = new Element("template");
-    
+
     /**
      * Enumeration of all available positions for notification component
      */
@@ -143,7 +143,11 @@ public class Notification
         Notification notification = new Notification(text, duration, position);
         notification.open();
         notification.addOpenedChangeListener(
-                event -> notification.getElement().removeFromParent());
+                event -> {
+                    if (notification.isOpened() == false) {
+                        notification.getElement().removeFromParent();
+                    }
+                });
         return notification;
     }
 

--- a/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -142,6 +142,8 @@ public class Notification
             Position position) {
         Notification notification = new Notification(text, duration, position);
         notification.open();
+        notification.addOpenedChangeListener(
+                event -> notification.getElement().removeFromParent());
         return notification;
     }
 

--- a/src/test/java/com/vaadin/flow/component/notification/tests/NotificationIT.java
+++ b/src/test/java/com/vaadin/flow/component/notification/tests/NotificationIT.java
@@ -55,6 +55,7 @@ public class NotificationIT extends ComponentDemoTest {
     public void notificationWithStaticConvenienceMethod() {
         checkNotificationIsOpen();
         assertNotificationOverlayContent("static");
+        checkNotificationIsClose();
         Assert.assertEquals(0,
                 findElements(By.id("static-notification")).size());
     }

--- a/src/test/java/com/vaadin/flow/component/notification/tests/NotificationIT.java
+++ b/src/test/java/com/vaadin/flow/component/notification/tests/NotificationIT.java
@@ -55,7 +55,7 @@ public class NotificationIT extends ComponentDemoTest {
     public void notificationWithStaticConvenienceMethod() {
         checkNotificationIsOpen();
         assertNotificationOverlayContent("static");
-        Assert.assertEquals(1,
+        Assert.assertEquals(0,
                 findElements(By.id("static-notification")).size());
     }
 


### PR DESCRIPTION
fix the Notification.show() method

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-notification-flow/18)
<!-- Reviewable:end -->
