### PR TITLE
Change duration type to int

### DIFF
--- a/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotification.java
+++ b/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotification.java
@@ -15,16 +15,17 @@
  */
 package com.vaadin.flow.component.notification;
 
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.ComponentSupplier;
 import javax.annotation.Generated;
-import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.dependency.HtmlImport;
-import com.vaadin.flow.component.Synchronize;
-import com.vaadin.flow.component.DomEvent;
+
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.ComponentSupplier;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.HasStyle;
+import com.vaadin.flow.component.Synchronize;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -68,22 +69,6 @@ public class GeneratedVaadinNotification<R extends GeneratedVaadinNotification<R
      */
     public double getDuration() {
         return getElement().getProperty("duration", 0.0);
-    }
-
-    /**
-     * <p>
-     * Description copied from corresponding location in WebComponent:
-     * </p>
-     * <p>
-     * The duration in milliseconds to show the notification. Set to {@code 0}
-     * or a negative number to disable the notification auto-closing.
-     * </p>
-     * 
-     * @param duration
-     *            the double value to set
-     */
-    public void setDuration(double duration) {
-        getElement().setProperty("duration", duration);
     }
 
     /**

--- a/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -105,7 +105,7 @@ public class Notification
         getElement().appendChild(templateElement);
         getElement().appendVirtualChild(container);
         setText(text);
-        setDuration((double) duration);
+        setDuration(duration);
         setPosition(position);
     }
 
@@ -178,6 +178,17 @@ public class Notification
      */
     public void setPosition(Position position) {
         this.setPosition(position.toString().toLowerCase().replace('_', '-'));
+    }
+
+    /**
+     * Set the duration in milliseconds to the notification. Set to {@code 0} or
+     * a negative number to disable the notification auto-closing.
+     * 
+     * @param duration
+     *            the duration of the notification
+     */
+    public void setDuration(int duration) {
+        getElement().setProperty("duration", duration);
     }
 
     /**


### PR DESCRIPTION
Type double is used in the Generated file, for user's convenience, type
int is more reasonable to be used.

Removed the setDuration from the generated file.
New generated file will be added

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-notification-flow/21)
<!-- Reviewable:end -->
