### PR TITLE
Notification is now removed from the DOM when closed

### DIFF
--- a/src/test/java/com/vaadin/flow/component/notification/tests/NotificationTestPage.java
+++ b/src/test/java/com/vaadin/flow/component/notification/tests/NotificationTestPage.java
@@ -41,6 +41,7 @@ public class NotificationTestPage extends Div {
         createNotificationAddMix();
         createNotificationwithTextAndAddComponent();
         createNotificationAddComponentAddText();
+        createNotificationOutsideUi();
     }
 
     private void createNotificationWithButtonControl() {
@@ -63,16 +64,15 @@ public class NotificationTestPage extends Div {
         button1.setId("notification-button-1");
         NativeButton button2 = new NativeButton(BUTTON_CAPTION + "2");
         button2.setId("notification-button-2");
-        Notification notification1 = new Notification(
-                "<h3>11111111111</h3>", 4000);
+        Notification notification1 = new Notification("<h3>11111111111</h3>",
+                4000);
         notification1.setId("notication-1");
-        Notification notification2 = new Notification(
-                "<h3>22222222222</h3>", 4000);
+        Notification notification2 = new Notification("<h3>22222222222</h3>",
+                4000);
         notification1.setId("notication-2");
         button1.addClickListener(event -> notification1.open());
         button2.addClickListener(event -> notification2.open());
-        add(notification1, button1,
-                notification2, button2);
+        add(notification1, button1, notification2, button2);
     }
 
     private void createNotificationAddComponent() {
@@ -186,8 +186,8 @@ public class NotificationTestPage extends Div {
     }
 
     private void createNotificationAddComponentAddText() {
-        Notification notificaiton = new Notification();
-        notificaiton.setId("add-component-add-text");
+        Notification notification = new Notification();
+        notification.setId("add-component-add-text");
         NativeButton button1 = new NativeButton(BUTTON_CAPTION);
         NativeButton button2 = new NativeButton("3333");
         NativeButton button3 = new NativeButton("BYE");
@@ -195,11 +195,26 @@ public class NotificationTestPage extends Div {
         button2.setId("add-component-add-text-two");
         button3.setId("add-component-add-text-close");
 
-        notificaiton.add(button2);
-        notificaiton.setText("Moi");
-        button1.addClickListener(event -> notificaiton.open());
-        button3.addClickListener(event -> notificaiton.close());
-        add(notificaiton, button1, button3);
+        notification.add(button2);
+        notification.setText("Moi");
+        button1.addClickListener(event -> notification.open());
+        button3.addClickListener(event -> notification.close());
+        add(notification, button1, button3);
+    }
+
+    private void createNotificationOutsideUi() {
+        Notification notification = new Notification();
+        notification.setDuration(4000);
+        notification.setId("notification-outside-ui");
+        NativeButton open = new NativeButton("Open detached");
+        NativeButton close = new NativeButton("Close detached");
+        open.setId("notification-outside-ui-open");
+        close.setId("notification-outside-ui-close");
+
+        notification.setText("Moi");
+        open.addClickListener(event -> notification.open());
+        close.addClickListener(event -> notification.close());
+        add(open, close);
     }
 
 }

--- a/src/test/java/com/vaadin/flow/component/notification/tests/NotificationTestPageIT.java
+++ b/src/test/java/com/vaadin/flow/component/notification/tests/NotificationTestPageIT.java
@@ -162,6 +162,23 @@ public class NotificationTestPageIT extends AbstractComponentIT {
         waitForElementNotPresent(By.id("notification-outside-ui"));
     }
 
+    @Test
+    public void notificationWithButtonControl_isNotRemovedOnClose() {
+        List<WebElement> notification = findElements(
+                By.id("notification-with-button-control"));
+        Assert.assertEquals(1, notification.size());
+
+        findElement(By.id("notification-open")).click();
+        checkNotificationIsOpen();
+        clickElementWithJs(findElement(By.id("notification-close")));
+        checkNotificationIsClose();
+
+        // since the notification was added manually in the DOM, it shouldn't be
+        // removed after close
+        notification = findElements(By.id("notification-with-button-control"));
+        Assert.assertEquals(1, notification.size());
+    }
+
     private void assertButtonSize(int number) {
         Assert.assertEquals(number, getNotifications().iterator().next()
                 .findElements(By.tagName("button")).size());

--- a/src/test/java/com/vaadin/flow/component/notification/tests/NotificationTestPageIT.java
+++ b/src/test/java/com/vaadin/flow/component/notification/tests/NotificationTestPageIT.java
@@ -30,7 +30,7 @@ import com.vaadin.flow.testutil.TestPath;
 @TestPath("notification-test")
 public class NotificationTestPageIT extends AbstractComponentIT {
 
-    private static final String NOTIFICATION_TAG = "vaadin-notification-card";
+    private static final String NOTIFICATION_CARD_TAG = "vaadin-notification-card";
 
     @Before
     public void init() {
@@ -55,15 +55,17 @@ public class NotificationTestPageIT extends AbstractComponentIT {
 
         checkNotificationIsOpen();
 
-        List<String> notifications = getNotifications().stream().map(WebElement::getText)
-                .collect(Collectors.toList());
+        List<String> notifications = getNotifications().stream()
+                .map(WebElement::getText).collect(Collectors.toList());
         Assert.assertEquals(
                 "Expect to have two notification pop-ups for two notification buttons clicked",
                 notifications.size(), 2);
         Assert.assertTrue("Expect to have the first notification shown",
-                notifications.stream().anyMatch(text -> text.contains("1111111")));
+                notifications.stream()
+                        .anyMatch(text -> text.contains("1111111")));
         Assert.assertTrue("Expect to have the second notification shown",
-                notifications.stream().anyMatch(text -> text.contains("2222222")));
+                notifications.stream()
+                        .anyMatch(text -> text.contains("2222222")));
     }
 
     @Test
@@ -109,8 +111,8 @@ public class NotificationTestPageIT extends AbstractComponentIT {
         findElement(By.id("Add-Mix-open")).click();
         checkNotificationIsOpen();
         assertButtonSize(1);
-        Assert.assertFalse(
-                getNotifications().iterator().next().getText().contains("5555555"));
+        Assert.assertFalse(getNotifications().iterator().next().getText()
+                .contains("5555555"));
         clickElementWithJs(findElement(By.id("add-Mix-close")));
         checkNotificationIsClose();
     }
@@ -134,17 +136,43 @@ public class NotificationTestPageIT extends AbstractComponentIT {
         checkNotificationIsClose();
     }
 
+    @Test
+    public void notificationNotAttachedToThePage_openAndClose_notificationIsAttachedAndRemoved() {
+        WebElement open = findElement(By.id("notification-outside-ui-open"));
+
+        waitForElementNotPresent(By.id("notification-outside-ui"));
+        open.click();
+        waitForElementPresent(By.id("notification-outside-ui"));
+        checkNotificationIsOpen();
+        try {
+            // wait for the notification to disappear
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        checkNotificationIsClose();
+        waitForElementNotPresent(By.id("notification-outside-ui"));
+
+        open.click();
+        waitForElementPresent(By.id("notification-outside-ui"));
+        checkNotificationIsOpen();
+        WebElement close = findElement(By.id("notification-outside-ui-close"));
+        close.click();
+        checkNotificationIsClose();
+        waitForElementNotPresent(By.id("notification-outside-ui"));
+    }
+
     private void assertButtonSize(int number) {
         Assert.assertEquals(number, getNotifications().iterator().next()
                 .findElements(By.tagName("button")).size());
     }
 
     private void checkNotificationIsClose() {
-        waitForElementNotPresent(By.tagName(NOTIFICATION_TAG));
+        waitForElementNotPresent(By.tagName(NOTIFICATION_CARD_TAG));
     }
 
     private void checkNotificationIsOpen() {
-        waitForElementPresent(By.tagName(NOTIFICATION_TAG));
+        waitForElementPresent(By.tagName(NOTIFICATION_CARD_TAG));
     }
 
     private void assertNotificationContent(String expected) {
@@ -158,6 +186,6 @@ public class NotificationTestPageIT extends AbstractComponentIT {
     }
 
     private List<WebElement> getNotifications() {
-        return findElements(By.tagName(NOTIFICATION_TAG));
+        return findElements(By.tagName(NOTIFICATION_CARD_TAG));
     }
 }


### PR DESCRIPTION
The Notification is removed when it is automatically added to the DOM during the open() call. If the user decides to add it to the DOM by himself, then the Notification is not removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-notification-flow/28)
<!-- Reviewable:end -->
