### PR TITLE
Notification.getChildren now returns the container's children

### DIFF
--- a/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -16,9 +16,12 @@
 package com.vaadin.flow.component.notification;
 
 import java.util.Locale;
+import java.util.stream.Stream;
+import java.util.stream.Stream.Builder;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.HtmlImport;
@@ -300,6 +303,14 @@ public class Notification extends GeneratedVaadinNotification<Notification>
     @Override
     public void removeAll() {
         container.removeAllChildren();
+    }
+
+    @Override
+    public Stream<Component> getChildren() {
+        Builder<Component> childComponents = Stream.builder();
+        container.getChildren().forEach(childElement -> ComponentUtil
+                .findComponents(childElement, childComponents::add));
+        return childComponents.build();
     }
 
     private void attachComponentTemplate(UI ui) {

--- a/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
+++ b/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.notification;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Label;
+
+/**
+ * Unit tests for the Notification.
+ */
+public class NotificationTest {
+
+    @Test
+    public void createNotificationWithComponents_componentsArePartOfGetChildren() {
+        Label label1 = new Label("Label 1");
+        Label label2 = new Label("Label 2");
+        Label label3 = new Label("Label 3");
+
+        Notification notification = new Notification(label1, label2);
+
+        List<Component> children = notification.getChildren()
+                .collect(Collectors.toList());
+        Assert.assertEquals(2, children.size());
+        Assert.assertThat(children, CoreMatchers.hasItems(label1, label2));
+
+        notification.add(label3);
+        children = notification.getChildren().collect(Collectors.toList());
+        Assert.assertEquals(3, children.size());
+        Assert.assertThat(children,
+                CoreMatchers.hasItems(label1, label2, label3));
+
+        notification.remove(label2);
+        children = notification.getChildren().collect(Collectors.toList());
+        Assert.assertEquals(2, children.size());
+        Assert.assertThat(children, CoreMatchers.hasItems(label1, label3));
+
+        label1.getElement().removeFromParent();
+        children = notification.getChildren().collect(Collectors.toList());
+        Assert.assertEquals(1, children.size());
+        Assert.assertThat(children, CoreMatchers.hasItems(label3));
+
+        notification.removeAll();
+        children = notification.getChildren().collect(Collectors.toList());
+        Assert.assertEquals(0, children.size());
+    }
+
+}

--- a/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
+++ b/src/test/java/com/vaadin/flow/component/notification/NotificationTest.java
@@ -23,6 +23,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
 
 /**
@@ -62,6 +63,20 @@ public class NotificationTest {
         notification.removeAll();
         children = notification.getChildren().collect(Collectors.toList());
         Assert.assertEquals(0, children.size());
+    }
+
+    @Test
+    public void createNotificationWithComponentsInsideComponent_onlyRootComponentsAreReturned() {
+        Div container1 = new Div();
+        Div container2 = new Div(container1);
+
+        Notification notification = new Notification(container2);
+        List<Component> children = notification.getChildren()
+                .collect(Collectors.toList());
+        Assert.assertEquals(1, children.size());
+        Assert.assertThat(children, CoreMatchers.hasItems(container2));
+        Assert.assertThat(children,
+                CoreMatchers.not(CoreMatchers.hasItem(container1)));
     }
 
 }


### PR DESCRIPTION
Related to https://github.com/vaadin/vaadin-dialog-flow/issues/34

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-notification-flow/29)
<!-- Reviewable:end -->
