### PR TITLE
Update generated component and fix API change

### DIFF
--- a/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotification.java
+++ b/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotification.java
@@ -15,17 +15,15 @@
  */
 package com.vaadin.flow.component.notification;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.ComponentEvent;
-import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.ComponentSupplier;
-import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.Synchronize;
+import com.vaadin.flow.component.ComponentSupplier;
+import javax.annotation.Generated;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.Synchronize;
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -46,7 +44,7 @@ Your work has been saved
  * </p>
  */
 @Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.0-SNAPSHOT",
-        "WebComponent: Vaadin.NotificationElement#1.0.0-alpha7",
+        "WebComponent: Vaadin.NotificationElement#1.0.0-beta1",
         "Flow#1.0-SNAPSHOT" })
 @Tag("vaadin-notification")
 @HtmlImport("frontend://bower_components/vaadin-notification/src/vaadin-notification.html")
@@ -178,11 +176,17 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
         getElement().callFunction("close");
     }
 
-    @DomEvent("opened-changed")
     public static class OpenedChangeEvent<R extends GeneratedVaadinNotification<R>>
             extends ComponentEvent<R> {
+        private final boolean opened;
+
         public OpenedChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.opened = source.isOpenedBoolean();
+        }
+
+        public boolean isOpened() {
+            return opened;
         }
     }
 
@@ -194,10 +198,12 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent<R>> listener) {
-        return addListener(OpenedChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("opened",
+                        event -> listener.onComponentEvent(
+                                new OpenedChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 }

--- a/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -91,8 +91,9 @@ public class Notification extends GeneratedVaadinNotification<Notification>
      */
     public Notification() {
         initBaseElementsAndListeners();
-        getElement().getNode().runWhenAttached(ui -> ui
-                .beforeClientResponse(this, () -> attachComponentTemplate(ui)));
+        getElement().getNode()
+                .runWhenAttached(ui -> ui.beforeClientResponse(this,
+                        context -> attachComponentTemplate(ui)));
         setPosition(Position.BOTTOM_START);
         setDuration(0);
     }
@@ -165,12 +166,13 @@ public class Notification extends GeneratedVaadinNotification<Notification>
         getElement().appendChild(templateElement);
         getElement().appendChild(container);
 
-        addOpenedChangeListener(event -> {
+        getElement().addEventListener("opened-changed", event -> {
             if (autoAddedToTheUi && !isOpened()) {
                 getElement().removeFromParent();
                 autoAddedToTheUi = false;
             }
         });
+
     }
 
     /**
@@ -207,7 +209,7 @@ public class Notification extends GeneratedVaadinNotification<Notification>
     public void setText(String text) {
         removeAll();
         getElement().getNode().runWhenAttached(
-                ui -> ui.beforeClientResponse(this, () -> templateElement
+                ui -> ui.beforeClientResponse(this, context -> templateElement
                         .setProperty("innerHTML", HtmlUtils.escape(text))));
     }
 
@@ -282,8 +284,9 @@ public class Notification extends GeneratedVaadinNotification<Notification>
             assert component != null;
             container.appendChild(component.getElement());
         }
-        getElement().getNode().runWhenAttached(ui -> ui
-                .beforeClientResponse(this, () -> attachComponentTemplate(ui)));
+        getElement().getNode()
+                .runWhenAttached(ui -> ui.beforeClientResponse(this,
+                        context -> attachComponentTemplate(ui)));
     }
 
     /**
@@ -347,7 +350,7 @@ public class Notification extends GeneratedVaadinNotification<Notification>
         UI ui = UI.getCurrent();
         if (opened && getElement().getNode().getParent() == null
                 && ui != null) {
-            ui.beforeClientResponse(ui, () -> {
+            ui.beforeClientResponse(ui, context -> {
                 ui.add(this);
                 autoAddedToTheUi = true;
             });


### PR DESCRIPTION
The new generated component uses `PropertyChangeListener` for `OpenedChangeEvents`, which means that server-side property-changes fire events immediately instead of waiting for client-side dom-event.
For removing the component when closing I had to revert to using the dom-event, because the value-change doesn't work after the component is removed.

The API change was that there's now a parameter for the lambda in `beforeClientResponse`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-notification-flow/32)
<!-- Reviewable:end -->
