### PR TITLE
Use the './' prefix in `@jsmodule`

### DIFF
--- a/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
+++ b/vaadin-notification-flow/src/main/java/com/vaadin/flow/component/notification/Notification.java
@@ -45,7 +45,7 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd
  */
 @HtmlImport("flow-component-renderer.html")
-@JsModule("flow-component-renderer.js")
+@JsModule("./flow-component-renderer.js")
 public class Notification extends GeneratedVaadinNotification<Notification>
         implements HasComponents, HasTheme {
 


### PR DESCRIPTION
This prevents the following warning in projects using vaadin-dialog-flow
>[WARNING] Use the './' prefix for resources in JAR files: 'flow-component-renderer.js', please update your component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-notification-flow/96)
<!-- Reviewable:end -->
