### PR TITLE
Notification card should be queried by tagName

### DIFF
--- a/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/NotificationTestPageIT.java
+++ b/vaadin-notification-flow-integration-tests/src/test/java/com/vaadin/flow/component/notification/tests/NotificationTestPageIT.java
@@ -220,7 +220,7 @@ public class NotificationTestPageIT extends AbstractComponentIT {
         waitForElementPresent(By.id("notification-add-component-at-index"));
         assertButtonNumberInNotification(initialNumber);
         findElement(By.id("close-notification-add-component-at-index")).click();
-        waitForElementNotPresent(By.id(NOTIFICATION_CARD_TAG));
+        waitForElementNotPresent(By.tagName(NOTIFICATION_CARD_TAG));
     }
 
     private void assertButtonNumberInNotification(int expectedButtonNumber) {


### PR DESCRIPTION
Otherwise it will find the DOM module `dom-module#vaadin-notification-card` in bower mode